### PR TITLE
Added animatedPadding feature

### DIFF
--- a/lib/src/flutter/animated/animated_container.dart
+++ b/lib/src/flutter/animated/animated_container.dart
@@ -25,9 +25,9 @@ import '../builder.dart';
 
 class VelocityAnimatedBox extends VelocityXWidgetBuilder<Widget>
     with
-        VelocityAlignmentMixing<VelocityAnimatedBox>,
-        VelocityDurationMixing<VelocityAnimatedBox>,
-        VelocityCurvesMixing<VelocityAnimatedBox>,
+        VelocityAlignmentMixin<VelocityAnimatedBox>,
+        VelocityDurationMixin<VelocityAnimatedBox>,
+        VelocityCurvesMixin<VelocityAnimatedBox>,
         VelocityColorMixin<VelocityAnimatedBox>,
         VelocityPaddingMixin<VelocityAnimatedBox>,
         VelocityRoundMixin<VelocityAnimatedBox>,

--- a/lib/src/flutter/animated/animated_padding.dart
+++ b/lib/src/flutter/animated/animated_padding.dart
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Pawan Kumar. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:velocity_x/src/flutter/velocityx_mixins/curves_mixin.dart';
+import 'package:velocity_x/src/flutter/velocityx_mixins/duration_mixin.dart';
+import '../builder.dart';
+
+class VelocityAnimatedPadding extends VelocityXWidgetBuilder<Widget>
+    with
+        VelocityDurationMixin<VelocityAnimatedPadding>,
+        VelocityCurvesMixin<VelocityAnimatedPadding> {
+  VelocityAnimatedPadding({this.child}) {
+    setChildForCurve(this);
+    setChildForDuration(this);
+  }
+  final Widget child;
+  EdgeInsetsGeometry _padding;
+
+  VelocityAnimatedPadding padding(EdgeInsetsGeometry val) =>
+      this.._padding = val;
+
+  @override
+  Widget make({Key key}) {
+    return AnimatedPadding(
+      padding: _padding,
+      duration: velocityDuration ?? const Duration(seconds: 1),
+      curve: velocityCurve ?? Curves.easeIn,
+      child: child,
+    );
+  }
+}
+
+extension AnimatedPaddingExtension on Widget {
+  VelocityAnimatedPadding get animatedPadding => VelocityAnimatedPadding(child: this);
+}

--- a/lib/src/flutter/container.dart
+++ b/lib/src/flutter/container.dart
@@ -24,7 +24,7 @@ import 'velocityx_mixins/round_mixin.dart';
 
 class VelocityBox extends VelocityXWidgetBuilder<Widget>
     with
-        VelocityAlignmentMixing<VelocityBox>,
+        VelocityAlignmentMixin<VelocityBox>,
         VelocityColorMixin<VelocityBox>,
         VelocityPaddingMixin<VelocityBox>,
         VelocityRoundMixin<VelocityBox>,

--- a/lib/src/flutter/velocityx_mixins/alignment_mixin.dart
+++ b/lib/src/flutter/velocityx_mixins/alignment_mixin.dart
@@ -13,7 +13,7 @@
 
 import 'package:flutter/material.dart';
 
-mixin VelocityAlignmentMixing<T> {
+mixin VelocityAlignmentMixin<T> {
   T _child;
 
   @protected

--- a/lib/src/flutter/velocityx_mixins/curves_mixin.dart
+++ b/lib/src/flutter/velocityx_mixins/curves_mixin.dart
@@ -13,7 +13,7 @@
 
 import 'package:flutter/material.dart';
 
-mixin VelocityCurvesMixing<T> {
+mixin VelocityCurvesMixin<T> {
   T _child;
 
   @protected

--- a/lib/src/flutter/velocityx_mixins/duration_mixin.dart
+++ b/lib/src/flutter/velocityx_mixins/duration_mixin.dart
@@ -13,7 +13,7 @@
 
 import 'package:flutter/material.dart';
 
-mixin VelocityDurationMixing<T> {
+mixin VelocityDurationMixin<T> {
   T _child;
 
   @protected


### PR DESCRIPTION
### Description

This PR adds basic `AnimatedPadding` extension on Widgets. And also fixes the typo for `curves_mixin.dart`, `duration_mixin.dart` and `padding_mixin.dart`

Syntax
```Dart
                       Container()
                           .animatedPadding
                           .padding(EdgeInsets.all(pad))
                           .bounceInOut.make()
```
Image
![animatedPadding](https://user-images.githubusercontent.com/25266736/78175686-e54abf00-7478-11ea-9882-aeec7d225fc4.gif)
