### PR TITLE
[StringExtension] Fixed eliminateFirst method

### DIFF
--- a/lib/src/extensions/string_ext.dart
+++ b/lib/src/extensions/string_ext.dart
@@ -24,7 +24,9 @@ extension StringExtension on String {
       : this;
 
   ///Removes first element
-  String get eliminateFirst => "${substring(1, length)}";
+  String get eliminateFirst => length > 1 
+      ? "${substring(1, length)}"
+      : "";
 
   /// Return a bool if the string is null or empty
   bool get isEmptyOrNull => this == null || isEmpty;


### PR DESCRIPTION
I noticed that If I pass an empty string to the eliminateFirst method the app will crash so I put a check on the length of the string.