### PR TITLE
Fixes #63

### DIFF
--- a/lib/src/flutter/textfield.dart
+++ b/lib/src/flutter/textfield.dart
@@ -282,7 +282,8 @@ class _VxTextFieldState extends State<VxTextField> {
 
   @override
   void dispose() {
-    controller?.dispose();
+    if(widget.controller == null)
+      controller?.dispose();
     focusNode?.dispose();
     super.dispose();
   }


### PR DESCRIPTION
## Description

When user was passing a `TextEditingController` and using `VxTextField` inside `ListView`, it was cause an error since as soon as `VxTextField` goes out of view, the dispose was also called on `TextEditingController` user passed.

Patch for stable