### PR TITLE
VxNavigator: Dynamic path routing

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/new/demo_list.dart';
+import 'package:example/new/vx_navigation.dart';
 import 'package:example/widgets/platform_widget.dart';
 import 'package:example/widgets/vx_shapes.dart';
 import 'package:flutter/cupertino.dart';
@@ -17,6 +18,13 @@ void main() {
       routerDelegate: VxNavigator(routes: {
         "/": (uri, param) => MaterialPage(child: DemoList()),
         "/demo": (uri, param) => MaterialPage(child: Demo()),
+        "/nav": (uri, param) => const MaterialPage(child: VxNavigation()),
+        RegExp(r"^\/nav\/[a-zA-Z0-9]+$"): (uri, param) => MaterialPage(
+              child: VxNavigation(
+                pathParam: uri.pathSegments[1],
+                queryParams: uri.queryParametersAll,
+              ),
+            ),
       }),
       theme: ThemeData(
         primarySwatch: Colors.blue,

--- a/example/lib/new/demo_list.dart
+++ b/example/lib/new/demo_list.dart
@@ -732,6 +732,16 @@ class DemoList extends StatelessWidget {
             DateTime.now().subtract(10.minutes).timeAgo().text.make(),
           ],
         ),
+        ListTile(
+          title: "VxNavigator".text.make(),
+          onTap: () => context.vxNav.push(Uri(
+            path: '/nav/path123',
+            queryParameters: {
+              'query': 'xyz',
+              'qlist': ['List', 'of', 'values']
+            },
+          )),
+        ),
       ]).scrollVertical(),
     );
   }

--- a/example/lib/new/vx_navigation.dart
+++ b/example/lib/new/vx_navigation.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:velocity_x/velocity_x.dart';
+
+class VxNavigation extends StatelessWidget {
+  final String pathParam;
+  final Map<String, List<String>> queryParams;
+
+  const VxNavigation({
+    Key? key,
+    this.pathParam = '',
+    this.queryParams = const {},
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: VxAppBar(title: "Vx Navigation".text.make()),
+      body: VStack(
+        [
+          VxTwoRow(
+            left: 'Path Param: '.text.bold.make(),
+            right: pathParam.text.make(),
+          ),
+          20.heightBox,
+          VxTwoRow(
+            left: 'Query Params: '.text.bold.make(),
+            right: queryParams
+                .map((k, v) => MapEntry(k, '$k=$v'))
+                .values
+                .map((x) => x.text.make())
+                .toList()
+                .vStack(),
+          ),
+        ],
+      ).centered(),
+    );
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -113,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -155,7 +155,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/nav/vx_delegate.dart
+++ b/lib/src/nav/vx_delegate.dart
@@ -13,7 +13,7 @@ class VxNavigator extends RouterDelegate<Uri>
   final navigatorKey = GlobalKey<NavigatorState>();
   late VxNavConfig routeManager;
   VxNavigator(
-      {required Map<String, VxPageBuilder> routes,
+      {required Map<Pattern, VxPageBuilder> routes,
       VxPageBuilder? notFoundPage}) {
     routeManager = VxNavConfig(
       routes: routes,

--- a/lib/src/nav/vx_nav.dart
+++ b/lib/src/nav/vx_nav.dart
@@ -9,7 +9,7 @@ import 'package:velocity_x/src/nav/vx_delegate.dart';
 class VxNavConfig extends ChangeNotifier {
   VxNavConfig({required this.routes, this.pageNotFound});
 
-  final Map<String, VxPageBuilder> routes;
+  final Map<Pattern, VxPageBuilder> routes;
   final VxPageBuilder? pageNotFound;
 
   final _pages = <Page>[];
@@ -28,7 +28,7 @@ class VxNavConfig extends ChangeNotifier {
     bool _findRoute = false;
     for (var i = 0; i < routes.keys.length; i++) {
       final key = routes.keys.elementAt(i);
-      if (key == uri.path) {
+      if (key.matchAsPrefix(uri.path)?.group(0) == uri.path) {
         if (_uris.contains(uri)) {
           final position = _uris.indexOf(uri);
           final _urisLengh = _uris.length;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -120,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -162,7 +162,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Allow VxNavigator to use regex along with strings

* This will help in routing path param related routes to same page,
  which can't be assigned statically using strings