### PR TITLE
Added toggle functionality to popup menu

### DIFF
--- a/lib/src/flutter/popup_menu.dart
+++ b/lib/src/flutter/popup_menu.dart
@@ -209,12 +209,24 @@ class _VxPopupMenuState extends State<VxPopupMenu> {
         child: widget.child,
         onTap: () {
           if (widget.clickType == VxClickType.singleClick) {
-            _showMenu();
+             if(!_controller!.menuIsShowing){
+               _showMenu();
+               _controller!.menuIsShowing = true;
+            }else{
+              _hideMenu();
+               _controller!.menuIsShowing = false;
+            }
           }
         },
         onLongPress: () {
           if (widget.clickType == VxClickType.longClick) {
-            _showMenu();
+             if(!_controller!.menuIsShowing){
+               _showMenu();
+               _controller!.menuIsShowing = true;
+            }else{
+              _hideMenu();
+               _controller!.menuIsShowing = false;
+            }
           }
         },
       ),


### PR DESCRIPTION
while popup menu is opened, clicking same button many times  causes to an error that attached is not true and it cant be removable from screen. Adding this feature prevents error and allows to remove popup tapping same widget. 