### PR TITLE
Null safety fix

### DIFF
--- a/lib/src/flutter/common/velocity_ensure_visible.dart
+++ b/lib/src/flutter/common/velocity_ensure_visible.dart
@@ -64,12 +64,12 @@ class _VxEnsureVisibleWhenFocusedState extends State<VxEnsureVisibleWhenFocused>
   void initState() {
     super.initState();
     widget.focusNode.addListener(_ensureVisible);
-    WidgetsBinding.instance.addObserver(this);
+    WidgetsFlutterBinding.addObserver(this);
   }
 
   @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
+    WidgetsFlutterBinding.removeObserver(this);
     widget.focusNode.removeListener(_ensureVisible);
     super.dispose();
   }

--- a/lib/src/flutter/common/velocity_ensure_visible.dart
+++ b/lib/src/flutter/common/velocity_ensure_visible.dart
@@ -64,12 +64,12 @@ class _VxEnsureVisibleWhenFocusedState extends State<VxEnsureVisibleWhenFocused>
   void initState() {
     super.initState();
     widget.focusNode.addListener(_ensureVisible);
-    WidgetsFlutterBinding.addObserver(this);
+    WidgetsBinding.instance?.addObserver(this);
   }
 
   @override
   void dispose() {
-    WidgetsFlutterBinding.removeObserver(this);
+    WidgetsBinding.instance?.removeObserver(this);
     widget.focusNode.removeListener(_ensureVisible);
     super.dispose();
   }

--- a/lib/src/flutter/drawer.dart
+++ b/lib/src/flutter/drawer.dart
@@ -147,7 +147,7 @@ class _VxDrawerState extends State<_VxDrawer> with TickerProviderStateMixin {
       ),
     );
 
-    WidgetsBinding.instance.addPostFrameCallback(getBoxHeight);
+    WidgetsFlutterBinding.addPostFrameCallback(getBoxHeight);
   }
 
   void getBoxHeight(Duration time) {

--- a/lib/src/flutter/drawer.dart
+++ b/lib/src/flutter/drawer.dart
@@ -147,7 +147,7 @@ class _VxDrawerState extends State<_VxDrawer> with TickerProviderStateMixin {
       ),
     );
 
-    WidgetsFlutterBinding.addPostFrameCallback(getBoxHeight);
+    WidgetsBinding.instance?.addPostFrameCallback(getBoxHeight);
   }
 
   void getBoxHeight(Duration time) {

--- a/lib/src/flutter/marquee.dart
+++ b/lib/src/flutter/marquee.dart
@@ -48,7 +48,7 @@ class VxMarqueeState extends State<VxMarquee>
   void initState() {
     super.initState();
     scrollController = ScrollController();
-    WidgetsBinding.instance.addPostFrameCallback((callback) {
+    WidgetsFlutterBinding.addPostFrameCallback((callback) {
       startTimer();
     });
   }

--- a/lib/src/flutter/marquee.dart
+++ b/lib/src/flutter/marquee.dart
@@ -48,7 +48,7 @@ class VxMarqueeState extends State<VxMarquee>
   void initState() {
     super.initState();
     scrollController = ScrollController();
-    WidgetsFlutterBinding.addPostFrameCallback((callback) {
+    WidgetsBinding.instance?.addPostFrameCallback((callback) {
       startTimer();
     });
   }

--- a/lib/src/flutter/popup_menu.dart
+++ b/lib/src/flutter/popup_menu.dart
@@ -183,7 +183,7 @@ class _VxPopupMenuState extends State<VxPopupMenu> {
     _controller = widget.controller;
     _controller ??= VxPopupMenuController();
     _controller!.addListener(_updateView);
-    WidgetsBinding.instance.addPostFrameCallback((call) {
+    WidgetsFlutterBinding.addPostFrameCallback((call) {
       _childBox = context.findRenderObject() as RenderBox?;
       _parentBox =
           Overlay.of(context)!.context.findRenderObject() as RenderBox?;

--- a/lib/src/flutter/popup_menu.dart
+++ b/lib/src/flutter/popup_menu.dart
@@ -183,7 +183,7 @@ class _VxPopupMenuState extends State<VxPopupMenu> {
     _controller = widget.controller;
     _controller ??= VxPopupMenuController();
     _controller!.addListener(_updateView);
-    WidgetsFlutterBinding.addPostFrameCallback((call) {
+    WidgetsBinding.instance?.addPostFrameCallback((call) {
       _childBox = context.findRenderObject() as RenderBox?;
       _parentBox =
           Overlay.of(context)!.context.findRenderObject() as RenderBox?;


### PR DESCRIPTION
Fix null safety issue for `WidgetBinding.instance` as it contains nullable value instead of assumed non-null. Tested compiled using Flutter 2.10.5 (Dart 2.16)