### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  intl: ^0.17.0
+  intl: ^0.18.0
   vector_math: ^2.1.2
   vxstate: ^2.3.0
 


### PR DESCRIPTION
Resolving dependencies...
Because no versions of flutter_localization match >0.1.10 <0.2.0 and flutter_localization 0.1.10 depends on flutter_localizations from sdk, flutter_localization ^0.1.10 requires flutter_localizations from sdk. And because every version of flutter_localizations from sdk depends on intl 0.18.0 and velocity_x >=2.4.0-nullsafety.0 depends on intl ^0.17.0, flutter_localization ^0.1.10 is incompatible with velocity_x >=2.4.0-nullsafety.0. So, because fluttertest depends on both velocity_x ^3.6.0 and flutter_localization ^0.1.10, version solving failed. exit code 1