### PR TITLE
Removed print from _buildToastWidget()

### DIFF
--- a/lib/src/flutter/toast.dart
+++ b/lib/src/flutter/toast.dart
@@ -205,7 +205,6 @@ class _VxToastViewState extends State<_VxToastView>
 
   /// Building the toast widget
   Widget _buildToastWidget() {
-    print(Theme.of(context).textTheme.headline6!.color);
     if (widget.type == VxToastType.text) {
       return Center(
         child: Card(


### PR DESCRIPTION
A print was added to the toast build method in #161  I simply removed it. 